### PR TITLE
Platform/oci efi

### DIFF
--- a/platform/golden/cfg/preseed-debian-11.cfg
+++ b/platform/golden/cfg/preseed-debian-11.cfg
@@ -18,6 +18,7 @@ d-i netcfg/get_hostname string golden
 d-i netcfg/get_domain string local
 d-i anna/choose_modules string network-console
 
+
 ###################
 ## Mirror defaults
 
@@ -50,15 +51,26 @@ tasksel tasksel/skip-tasks  string standard
 tasksel tasksel/first multiselect openssh-server
 popularity-contest popularity-contest/participate boolean false
 
-d-i pkgsel/include string curl wget openssh-server neovim sudo cloud-init
+d-i pkgsel/include string curl wget openssh-server neovim sudo cloud-init ovmf grub-efi-amd64
 d-i pkgsel/language-pack-patterns   string
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/upgrade select full-upgrade
 
+# -------- Hardware Firmware --------
+d-i hw-detect/load_firmware boolean true
+
 ###########
 ## Use XFS
 
+# Force UEFI booting ('BIOS compatibility' will be lost). Default: false.
+d-i partman-efi/non_efi_system boolean true
+
+# Ensure the partition table is GPT - this is required for EFI
+d-i partman-partitioning/choose_label select gpt
+d-i partman-partitioning/default_label string gpt
 d-i partman/default_filesystem string xfs
+
+# Use raw partitions 
 d-i partman-auto/method string regular
 
 ###################
@@ -69,6 +81,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
+d-i partman-basicfilesystems/no_swap boolean false
 
 ####################
 ## Additional media
@@ -82,6 +95,8 @@ d-i apt-setup/contrib boolean false
 ## Bootloader defaults
 
 d-i grub-installer/only_debian boolean true
+d-i grub-installer/efi/non_removable_path boolean true
+d-i grub-installer/efi/removable_media boolean false
 d-i grub-installer/bootdev  string default
 
 #####################

--- a/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/handlers/main.yml
+++ b/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/handlers/main.yml
@@ -1,4 +1,0 @@
----
-- name: update grub
-  ansible.builtin.command: update-grub
-  when: ansible_os_family == 'Debian'

--- a/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/tasks/main.yml
+++ b/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/tasks/main.yml
@@ -1,29 +1,25 @@
 ---
 # Fix user setup for packer user
-
 #  lock password to avoid password logins
-
 - name: Lock packer user password to prevent password reset or login
   ansible.builtin.user:
     name: packer
     password: '*'
 
 #  update authorized keys from @sdake and @rstarmer
-
 - name: Set authorized keys for packer user - sdake
   ansible.posix.authorized_key:
     user: packer
     state: present
     key: "{{ lookup('url', 'https://github.com/sdake.keys', split_lines=False) }}"
 
-- name: Set authorized keys for packer user - sdake
+- name: Set authorized keys for packer user - rstarmer
   ansible.posix.authorized_key:
     user: packer
     state: present
     key: "{{ lookup('url', 'https://github.com/rstarmer.keys', split_lines=False) }}"
 
 # Update apt package cache and installed packages to latest versions
-
 - name: update apt packages
   ansible.builtin.apt:
     update_cache: true
@@ -35,7 +31,6 @@
   ansible.builtin.apt:
     name: open-iscsi
     state: present
-
 # Potential Fixes from https://github.com/oracle-quickstart/oci-byo-image/blob/master/scripts/debian_10.6/OCI.sh
 
 # add libpamd
@@ -64,4 +59,3 @@
 
 - name: update grub
   ansible.builtin.command: update-grub
-

--- a/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/tasks/main.yml
+++ b/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/tasks/main.yml
@@ -5,57 +5,42 @@
   ansible.builtin.user:
     name: packer
     password: '*'
-
-#  update authorized keys from @sdake and @rstarmer
 - name: Set authorized keys for packer user - sdake
   ansible.posix.authorized_key:
     user: packer
     state: present
     key: "{{ lookup('url', 'https://github.com/sdake.keys', split_lines=False) }}"
-
 - name: Set authorized keys for packer user - rstarmer
   ansible.posix.authorized_key:
     user: packer
     state: present
     key: "{{ lookup('url', 'https://github.com/rstarmer.keys', split_lines=False) }}"
-
-# Update apt package cache and installed packages to latest versions
 - name: update apt packages
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
     upgrade: true
-
-# Fix grub config to support tty at boot
 - name: add iscsi packages
   ansible.builtin.apt:
     name: open-iscsi
     state: present
 # Potential Fixes from https://github.com/oracle-quickstart/oci-byo-image/blob/master/scripts/debian_10.6/OCI.sh
-
-# add libpamd
 - name: add libpam
   ansible.builtin.apt:
     name: libpam-systemd
     state: present
-
-# fix /etc/network/interfaces replacing en[sp][0-9]* with eth0
 - name: fix /etc/network/interfaces
   ansible.builtin.replace:
     path: /etc/network/interfaces
     regexp: 'en[sp][0-9]*'
     replace: 'eth0'
-
-# add pre-up delay to network interfaces to support dhclient
 - name: add pre-up delay to network interfaces
   ansible.builtin.lineinfile:
     path: /etc/network/interfaces
     line: 'pre-up sleep 2'
-
 - name: Update grub2 config to support tty at boot
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     line: 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ip=dhcp console=tty0 console=ttyS0 nvme.shutdown_timeout=10 libiscsi.debug_libiscsi_eh=1 netroot=iscsi:@169.254.0.2::::iqn.2015-02.oracle.boot:uefi iscsi_initiator=iqn.2015-02.oracle.boot:instance iommu=on net.ifnames=0 biosdevname=0"'
-
 - name: update grub
   ansible.builtin.command: update-grub

--- a/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/tasks/main.yml
+++ b/platform/golden/provisioners/01_update_packer_user/roles/packer-finalize/tasks/main.yml
@@ -31,9 +31,37 @@
     upgrade: true
 
 # Fix grub config to support tty at boot
+- name: add iscsi packages
+  ansible.builtin.apt:
+    name: open-iscsi
+    state: present
+
+# Potential Fixes from https://github.com/oracle-quickstart/oci-byo-image/blob/master/scripts/debian_10.6/OCI.sh
+
+# add libpamd
+- name: add libpam
+  ansible.builtin.apt:
+    name: libpam-systemd
+    state: present
+
+# fix /etc/network/interfaces replacing en[sp][0-9]* with eth0
+- name: fix /etc/network/interfaces
+  ansible.builtin.replace:
+    path: /etc/network/interfaces
+    regexp: 'en[sp][0-9]*'
+    replace: 'eth0'
+
+# add pre-up delay to network interfaces to support dhclient
+- name: add pre-up delay to network interfaces
+  ansible.builtin.lineinfile:
+    path: /etc/network/interfaces
+    line: 'pre-up sleep 2'
 
 - name: Update grub2 config to support tty at boot
   ansible.builtin.lineinfile:
     path: /etc/default/grub
-    line: 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX console=ttyS0"'
-  notify: update grub
+    line: 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ip=dhcp console=tty0 console=ttyS0 nvme.shutdown_timeout=10 libiscsi.debug_libiscsi_eh=1 netroot=iscsi:@169.254.0.2::::iqn.2015-02.oracle.boot:uefi iscsi_initiator=iqn.2015-02.oracle.boot:instance iommu=on net.ifnames=0 biosdevname=0"'
+
+- name: update grub
+  ansible.builtin.command: update-grub
+


### PR DESCRIPTION
Changes needed to build an UEFI based image targeting OCI.

Note that this still does not appear to boot properly on OCI bare metal instances, likely due to missing resources to support iSCSI boot.

Major changes include a re-work of the D-I boot process (and UEFI grub boot loader differentiation both in VirtualBox-ISO plugin for packer, and in configuring the packer environment).

In addition, an attempt has been made in the post initial install configuration to support the changes needed for iscsi boot in the provisioner folder (ansible role).