### PR TITLE
DRAFT: Add bash based build on Ubuntu for faiss library and prerequisites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-build*/
+build/
+faiss*
+faiss/

--- a/platform/build-faiss/README.md
+++ b/platform/build-faiss/README.md
@@ -1,0 +1,32 @@
+#! Set up an Ubuntu 22.04 machine to build FAISS
+
+Assumptions:
+
+/dev/nvme0n1 exists and can be reformatted
+NVIDIA GPU installed
+
+## base setup
+
+Add python prerequisites
+Mount /dev/nvme0n1 on /models
+Link .cache and .local from ubuntu to /models
+
+```sh
+bash add_dev.sh
+```
+
+## Build prerequisites
+
+Add Nvidia and Intel OneAPK libraries needed to build FAISS
+
+```sh
+bash faiss-prereqs.sh
+```
+
+## Build FAISS
+
+Download the git repository and build it!
+
+```sh
+bash build-faiss.sh
+``` 

--- a/platform/build-faiss/add_dev.sh
+++ b/platform/build-faiss/add_dev.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+sudo apt-get update && sudo apt-get dist-upgrade -y
+
+# Install python and build essentials and essential libraries
+sudo apt-get install -y python3-venv python3-pip python3-dev build-essential libssl-dev libffi-dev libxml2-dev libxslt1-dev liblzma-dev libsqlite3-dev libreadline-dev libbz2-dev
+
+sudo pip install -U pip setuptools
+
+# mount nvme disk on /models
+sudo mkdir /models
+sudo mkfs.xfs /dev/nvme0n1
+echo '/dev/nvme0n1  /models xfs defaults  0  2' | sudo tee -a /etc/fstab
+sudo mount -a
+sudo chmod 777 /models
+
+# Add pointers to large data dirs into the 'ubuntu' user $HOME
+mkdir /models/cache
+mv ~/.cache ~/.cache.orig
+ln -s /models/cache ~/.cache
+mkdir /models/dev
+ln -s /models/dev
+mkdir /models/local
+ln -s /models/local ~/.local
+
+echo 'export PATH=$HOME/.local/bin:$PATH' >> ~/.bashrc
+
+
+

--- a/platform/build-faiss/build-faiss.sh
+++ b/platform/build-faiss/build-faiss.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+git clone https://github.com/facebookresearch/faiss
+cd faiss
+
+# Configure paths and set environment variables
+export PATH=$PATH:$HOME/.local/bin:/usr/local/cuda/bin
+source /opt/intel/oneapi/setvars.sh
+
+#export CC=gcc-12
+#export CXX=g++-12
+# Configure using cmake
+
+LD_LIBRARY_PATH=/usr/local/lib MKLROOT=/opt/intel/oneapi/mkl/2023.1.0/ CXX=g++-11 cmake -B build \
+	-DBUILD_SHARED_LIBS=ON \
+	-DBUILD_TESTING=ON \
+	-DFAISS_ENABLE_GPU=ON \
+	-DFAISS_OPT_LEVEL=axv2 \
+	-DFAISS_ENABLE_C_API=ON \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DBLA_VENDOR=Intel10_64_dyn -Wno-dev .
+#cmake -B build . \
+        -DBUILD_SHARED_LIBS=ON \
+	-DFAISS_ENABLE_GPU=ON \
+	-DFAISS_ENABLE_PYTHON=ON \
+	-DFAISS_ENABLE_RAFT=OFF \
+	-DBUILD_TESTING=ON \
+	-DBUILD_SHARED_LIBS=ON \
+	-DFAISS_ENABLE_C_API=ON \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DFAISS_OPT_LEVEL=avx2 -Wno-dev
+
+# Now build faiss
+
+make -C build -j$(nproc) faiss
+make -C build -j$(nproc) swigfaiss
+pushd build/faiss/python;python3 setup.py bdist_wheel;popd
+
+# and install it. NOTE: this will install into the pyenv virtualenv 'aw' from the begining of the script
+
+sudo -E make -C build -j$(nproc) install
+pip install --force-reinstall build/faiss/python/dist/faiss-1.7.4-py3-none-any.whl
+cp build/faiss/python/dist/faiss-1.7.4-py3-none-any.whl ../
+
+# add libraries to /usr/local/lib
+mkdir -p faiss-libs
+
+for n in build/faiss/python/*so build/faiss/*so
+  do
+    sudo cp $n /usr/local/lib/
+    cp $n faiss-libs/
+  done
+tar cfz ../faiss-libs.tgz faiss-libs/*
+rm -rf faiss-libs
+
+# Add ldconfig settings for intel and faiss libraries
+
+echo '/opt/intel/oneapi/mkl/2023.1.0/lib/intel64' | sudo tee /etc/ld.so.conf.d/aw_intel.conf
+echo '/usr/local/lib' | sudo tee /etc/ld.so.conf.d/aw_faiss.conf
+
+# Update the ld cache
+
+sudo -E ldconfig
+
+cd ..
+rm -rf faiss

--- a/platform/build-faiss/build-prereqs.sh
+++ b/platform/build-faiss/build-prereqs.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+
+# Add a couple Python prerequisites
+pip install -U pip setuptools wheel
+pip install numpy swig torch
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Get Intel OneAPI for BLAS support
+# From: https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-0/apt.html
+
+# download the key to system keyring
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+# add signed entry to apt sources and configure the APT client to use Intel repository:
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+
+sudo -E apt update
+sudo -E apt install dkms intel-basekit -y
+
+## Get CUDA and install it
+
+curl -sLO https://developer.download.nvidia.com/compute/cuda/12.2.0/local_installers/cuda_12.2.0_535.54.03_linux.run
+sudo bash $PWD/cuda_*run --silent --toolkit --driver --no-man-page
+
+# ensure we're using the latest cmake
+wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
+# add the cuda tools to build against
+
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo -E apt-get update
+sudo -E apt-get install cmake cuda-toolkit -y
+
+#Verify python and pytorch work
+
+python3 -c 'import torch; print(f"Is CUDA Available: {torch.cuda.is_available()}")'
+


### PR DESCRIPTION
add_dev.sh: ensure disk space for build and python prerequisites
build-prereqs.sh: install prerequisites (intel, nvidia)
build-faiss.sh: build faiss libs and python (and python swig) libs

Produces a python .whl
Produces a .tar.gz of the generated libraries