### PR TITLE
Fix CI for Dockerfiles

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         path:
-          - platform/packaging/build/faiss
           - workloads/dataset-controller
           - workloads/jupyterlab
           - workloads/retro-next/build_knowledge_base


### PR DESCRIPTION
Remove a missing Dockerfile from the list. I checked: all of the other Dockerfiles build locally for me.