### PR TITLE
Hypervisor v40

### DIFF
--- a/platform/Dockerfiles/cloud-hypervisor/Dockerfile
+++ b/platform/Dockerfiles/cloud-hypervisor/Dockerfile
@@ -1,9 +1,9 @@
 FROM docker.io/library/debian:bookworm as build_cloud_hypervisor
 
 ENV DEBIAN_FRONTEND           noninteractive
-ENV RUST_VERSION              1.78.0
+ENV RUST_VERSION              1.80.0
 ENV RUST_ARCH                 x86_64
-ENV CLOUD_HYPERVISOR_VERSION  v39.0
+ENV CLOUD_HYPERVISOR_VERSION  40.0
 
 ENV PATH                      "$PATH:/root/.cargo/bin/"
 
@@ -47,7 +47,7 @@ RUN cargo install cargo-deb --locked
 # Prepare and build cloud-hypervisor
 
 WORKDIR /workspace/build
-RUN git clone --filter=tree:0 -b ${CLOUD_HYPERVISOR_VERSION} https://github.com/cloud-hypervisor/cloud-hypervisor cloud-hypervisor-${CLOUD_HYPERVISOR_VERSION}
+RUN git clone --filter=tree:0 -b v${CLOUD_HYPERVISOR_VERSION} https://github.com/cloud-hypervisor/cloud-hypervisor cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}
 
 
 ###
@@ -55,8 +55,9 @@ RUN git clone --filter=tree:0 -b ${CLOUD_HYPERVISOR_VERSION} https://github.com/
 # TODO(sdake): Define features
 # https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
 
-WORKDIR /workspace/build/cloud-hypervisor-${CLOUD_HYPERVISOR_VERSION}
-RUN cargo rustc --release --locked --bin="cloud-hypervisor" --no-default-features --features="kvm,io_uring"  --target="${RUST_ARCH}-unknown-linux-musl" --future-incompat-report -- -D warnings -D clippy::undocumented_unsafe_blocks
+WORKDIR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}
+RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separate-debug-symbols --compress-debug-symbols
+
 
 ###
 #
@@ -64,7 +65,9 @@ RUN cargo rustc --release --locked --bin="cloud-hypervisor" --no-default-feature
 # And then placed in ${PWD}/target
 
 WORKDIR /workspace/target
-RUN cp -aR /workspace/build/cloud-hypervisor-${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/cloud-hypervisor /workspace/target/cloud_hypervisor_${CLOUD_HYPERVISOR_VERSION}
+RUN cp -aR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/cloud-hypervisor /workspace/target/cloud-hypervisor_v${CLOUD_HYPERVISOR_VERSION}
+RUN cp -aR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/ch-remote /workspace/target/ch-remote_v${CLOUD_HYPERVISOR_VERSION}
+RUN cp -aR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/debian/cloud-hypervisor_${CLOUD_HYPERVISOR_VERSION}.0-1_amd64.deb /workspace/target
 
 FROM scratch
 COPY --from=build_cloud_hypervisor /workspace/target /

--- a/platform/Dockerfiles/cloud-hypervisor/Dockerfile
+++ b/platform/Dockerfiles/cloud-hypervisor/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /workspace/install
 RUN curl --location --remote-name https://static.rust-lang.org/rustup/dist/${RUST_ARCH}-unknown-linux-gnu/rustup-init
 RUN chmod +x rustup-init
 RUN ./rustup-init -y --profile=minimal --default-host=${RUST_ARCH}-unknown-linux-gnu --default-toolchain=${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu --target=${RUST_ARCH}-unknown-linux-musl
-RUN cargo install cargo-feature --locked
+# 1-liner to list project features: cargo metadata --format-version=1 --no-deps | jq '.packages[].features | keys'
 RUN cargo install cargo-deb --locked
 
 

--- a/platform/Dockerfiles/cloud-hypervisor/Dockerfile
+++ b/platform/Dockerfiles/cloud-hypervisor/Dockerfile
@@ -1,4 +1,9 @@
-FROM docker.io/library/debian:bookworm AS build_cloud_hypervisor
+# syntax=docker/dockerfile:1
+FROM docker.io/library/debian:12 AS build_cloud_hypervisor
+LABEL "com.computelify.vendor"="Computelify, Inc."
+LABEL "cloud.artificialwisdom.vendor"="The Artificial Wisdom Cloud"
+LABEL "version"="v1.80.0"
+LABEL "description"="debian/cloud-hypervisor"
 
 ENV DEBIAN_FRONTEND           noninteractive
 ENV RUST_VERSION              1.80.0

--- a/platform/Dockerfiles/cloud-hypervisor/Dockerfile
+++ b/platform/Dockerfiles/cloud-hypervisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:bookworm as build_cloud_hypervisor
+FROM docker.io/library/debian:bookworm AS build_cloud_hypervisor
 
 ENV DEBIAN_FRONTEND           noninteractive
 ENV RUST_VERSION              1.80.0
@@ -32,10 +32,9 @@ RUN apt --yes install liblzma-dev
 ###
 #
 # Install rustup-init, which then installs the host toolchain, target toolchain, and cargo commands
-# https://doc.rust-lang.org/cargo/reference/unstable.html#list-of-unstable-features
 
 WORKDIR /workspace/install
-RUN curl -LO https://static.rust-lang.org/rustup/dist/${RUST_ARCH}-unknown-linux-gnu/rustup-init
+RUN curl --location --remote-name https://static.rust-lang.org/rustup/dist/${RUST_ARCH}-unknown-linux-gnu/rustup-init
 RUN chmod +x rustup-init
 RUN ./rustup-init -y --profile=minimal --default-host=${RUST_ARCH}-unknown-linux-gnu --default-toolchain=${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu --target=${RUST_ARCH}-unknown-linux-musl
 RUN cargo install cargo-feature --locked
@@ -49,20 +48,13 @@ RUN cargo install cargo-deb --locked
 WORKDIR /workspace/build
 RUN git clone --depth 1 --branch v${CLOUD_HYPERVISOR_VERSION} https://github.com/cloud-hypervisor/cloud-hypervisor cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}
 
-
-###
-#
-# TODO(sdake): Define features
-# https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
-
 WORKDIR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}
 RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separate-debug-symbols --compress-debug-symbols
 
 
 ###
 #
-# Output the build by copying the file to a new layer
-# And then placed in ${PWD}/target
+# Output the build by placing in ${PWD}/target
 
 WORKDIR /workspace/target
 RUN cp --archive --recursive /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/cloud-hypervisor /workspace/target/cloud-hypervisor_v${CLOUD_HYPERVISOR_VERSION}

--- a/platform/Dockerfiles/cloud-hypervisor/Dockerfile
+++ b/platform/Dockerfiles/cloud-hypervisor/Dockerfile
@@ -13,20 +13,20 @@ ENV PATH                      "$PATH:/root/.cargo/bin/"
 # global build dependencies
 
 RUN apt update
-RUN apt -y install curl
-RUN apt -y install git
-RUN apt -y install build-essential
-RUN apt -y install pkg-config
-RUN apt -y install musl-tools
+RUN apt --yes install curl
+RUN apt --yes install git
+RUN apt --yes install build-essential
+RUN apt --yes install pkg-config
+RUN apt --yes install musl-tools
 
 
 ###
 #
 # Runtime dependencies for cargo-deb
 
-RUN apt -y install dpkg
-RUN apt -y install dpkg-dev
-RUN apt -y install liblzma-dev
+RUN apt --yes install dpkg
+RUN apt --yes install dpkg-dev
+RUN apt --yes install liblzma-dev
 
 
 ###
@@ -47,7 +47,7 @@ RUN cargo install cargo-deb --locked
 # Prepare and build cloud-hypervisor
 
 WORKDIR /workspace/build
-RUN git clone --filter=tree:0 -b v${CLOUD_HYPERVISOR_VERSION} https://github.com/cloud-hypervisor/cloud-hypervisor cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}
+RUN git clone --depth 1 --branch v${CLOUD_HYPERVISOR_VERSION} https://github.com/cloud-hypervisor/cloud-hypervisor cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}
 
 
 ###
@@ -65,30 +65,9 @@ RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separ
 # And then placed in ${PWD}/target
 
 WORKDIR /workspace/target
-RUN cp -aR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/cloud-hypervisor /workspace/target/cloud-hypervisor_v${CLOUD_HYPERVISOR_VERSION}
-RUN cp -aR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/ch-remote /workspace/target/ch-remote_v${CLOUD_HYPERVISOR_VERSION}
-RUN cp -aR /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/debian/cloud-hypervisor_${CLOUD_HYPERVISOR_VERSION}.0-1_amd64.deb /workspace/target
+RUN cp --archive --recursive /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/cloud-hypervisor /workspace/target/cloud-hypervisor_v${CLOUD_HYPERVISOR_VERSION}
+RUN cp --archive --recursive /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/ch-remote /workspace/target/ch-remote_v${CLOUD_HYPERVISOR_VERSION}
+RUN cp --archive --recursive /workspace/build/cloud-hypervisor-v${CLOUD_HYPERVISOR_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/debian/cloud-hypervisor_${CLOUD_HYPERVISOR_VERSION}.0-1_amd64.deb /workspace/target
 
 FROM scratch
 COPY --from=build_cloud_hypervisor /workspace/target /
-
-# TODO: cargo deb will build a debian package for us
-# Although I wish to maintain the capability to have multiple hypervisor versions
-# on the same filesystem at the same time.
-#
-###
-
-
-# These may be important to follow up with, or they may be uninteresting.
-#
-# https://doc.rust-lang.org/rustc/linker-plugin-lto.html
-# https://github.com/rust-cuda/wg/blob/master/documents/roadmap.md
-# https://github.com/japaric-archived/nvptx#targets
-# https://llvm.org/docs/LinkTimeOptimization.html
-# https://doc.rust-lang.org/cargo/reference/profiles.html#profile-settings
-# Environment: https://doc.rust-lang.org/cargo/reference/environment-variables.html
-# https://doc.rust-lang.org/cargo/reference/config.html#configuration-format
-# https://doc.rust-lang.org/cargo/reference/environment-variables.html
-# https://doc.rust-lang.org/cargo/commands/cargo-vendor.html
-# https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5941
-# https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/programmer-references/24593.pdf

--- a/platform/Dockerfiles/cloud-hypervisor/build.sh
+++ b/platform/Dockerfiles/cloud-hypervisor/build.sh
@@ -1,6 +1,6 @@
-CLOUD_HYPERVISOR_VERSION=v39.0
+CLOUD_HYPERVISOR_VERSION=40.0
 date=$(date '+%Y%m%d%H%M%S')
 
-docker buildx build --tag artificialwisdomai/cloud-hypervisor:${CLOUD_HYPERVISOR_VERSION}-${date} --output type=docker --progress plain .
-docker buildx build --tag artificialwisdomai/cloud-hypervisor:${CLOUD_HYPERVISOR_VERSION}-${date} --output type=local,dest="${PWD}/target" --progress plain .
-docker buildx build --tag artificialwisdomai/cloud-hypervisor:${CLOUD_HYPERVISOR_VERSION} --output type=docker --progress plain .
+docker buildx build --tag artificialwisdomai/cloud-hypervisor:v${CLOUD_HYPERVISOR_VERSION} --output type=docker --progress plain .
+docker buildx build --tag artificialwisdomai/cloud-hypervisor:v${CLOUD_HYPERVISOR_VERSION}-${date} --output type=docker --progress plain .
+docker buildx build --tag artificialwisdomai/cloud-hypervisor:v${CLOUD_HYPERVISOR_VERSION}-${date} --output type=local,dest="${PWD}/target" --progress plain .


### PR DESCRIPTION
    Revise rust from 1.78 to 1.80
    Simplify build by removing rustc execution
    Revise cloud-hypervisor from v39 to v40
    Output debian packages with cargo-deb
