### PR TITLE
Virtiofs v1.11.1

### DIFF
--- a/platform/Dockerfiles/virtiofsd/Dockerfile
+++ b/platform/Dockerfiles/virtiofsd/Dockerfile
@@ -90,7 +90,6 @@ RUN git clone --depth 1 --branch v${LIBSECCOMP_VERSION} https://github.com/secco
 WORKDIR /workspace/build/libseccomp-v${LIBSECCOMP_VERSION}
 RUN bash autogen.sh
 RUN ./configure --enable-shared="no" --enable-static="yes" --enable-silent-rules="no" --prefix="/usr"
-RUN ls -lR /workspace/build
 RUN make
 RUN make install
 

--- a/platform/Dockerfiles/virtiofsd/Dockerfile
+++ b/platform/Dockerfiles/virtiofsd/Dockerfile
@@ -1,10 +1,17 @@
-FROM docker.io/library/debian:bookworm AS toolchain
+# syntax=docker/dockerfile:1
+FROM docker.io/library/debian:12 AS toolchain
+LABEL "com.computelify.vendor"="Computelify, Inc."
+LABEL "cloud.artificialwisdom.vendor"="The Artificial Wisdom Cloud"
+LABEL "version"="v1.11.1"
+LABEL "description"="debian/virtiofsd"
 
-ENV DEBIAN_FRONTEND           noninteractive
-ENV RUST_VERSION              1.80.0
-ENV RUST_ARCH                 x86_64
 
-ENV PATH                      "$PATH:/root/.cargo/bin/"
+ENV VIRTIOFSD_VERSION="1.11.1"
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV RUST_VERSION="1.80.0"
+ENV RUST_ARCH="x86_64"
+
+ENV PATH="$PATH:/root/.cargo/bin/"
 
 
 ###
@@ -105,15 +112,15 @@ RUN make install
 # Prepare final application
 
 FROM dependencies AS build_virtiofsd
-ENV PATH                      "$PATH:/root/.cargo/bin/"
-ENV RUST_VERSION              1.80.0
-ENV RUST_ARCH                 x86_64
-ENV VIRTIOFSD_VERSION         1.11.1
-ENV RUSTFLAGS                 "--codegen target-feature=+crt-static --codegen link-self-contained=yes"
-ENV LIBSECCOMP_LINK_TYPE      "static"
-ENV LIBSECCOMP_LIB_PATH       "/usr/lib"
-ENV LIBCAPNG_LINK_TYPE        "static"
-ENV LIBCAPNG_LIB_PATH         "/usr/lib"
+ENV PATH="$PATH:/root/.cargo/bin/"
+ENV RUST_VERSION="1.80.0"
+ENV RUST_ARCH="x86_64"
+ENV VIRTIOFSD_VERSION="1.11.1"
+ENV RUSTFLAGS="--codegen target-feature=+crt-static --codegen link-self-contained=yes"
+ENV LIBSECCOMP_LINK_TYPE="static"
+ENV LIBSECCOMP_LIB_PATH="/usr/lib"
+ENV LIBCAPNG_LINK_TYPE="static"
+ENV LIBCAPNG_LIB_PATH="/usr/lib"
 
 
 ###
@@ -124,8 +131,8 @@ WORKDIR /workspace/build/
 RUN git clone --depth 1 --branch v${VIRTIOFSD_VERSION} https://gitlab.com/virtio-fs/virtiofsd virtiofsd-v${VIRTIOFSD_VERSION}
 
 WORKDIR /workspace/build/"virtiofsd-v${VIRTIOFSD_VERSION}"
-# Need the virtiofsd features. --all-features was here prior
-RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separate-debug-symbols --compress-debug-symbols -- --all-features
+RUN cargo build --release --target=${RUST_ARCH}-unknown-linux-musl --all-features
+RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separate-debug-symbols --compress-debug-symbols
 
 
 ###

--- a/platform/Dockerfiles/virtiofsd/Dockerfile
+++ b/platform/Dockerfiles/virtiofsd/Dockerfile
@@ -56,7 +56,6 @@ WORKDIR /workspace/install
 RUN curl --location --remote-name https://static.rust-lang.org/rustup/dist/${RUST_ARCH}-unknown-linux-gnu/rustup-init
 RUN chmod +x rustup-init
 RUN ./rustup-init -y --profile=minimal --default-host=${RUST_ARCH}-unknown-linux-gnu --default-toolchain=${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu --target=${RUST_ARCH}-unknown-linux-musl
-RUN cargo install cargo-feature --locked
 RUN cargo install cargo-deb --locked
 
 
@@ -102,7 +101,7 @@ RUN make install
 
 WORKDIR /workspace/build/libcap-ng-v${LIBCAP_NG_VERSION}
 RUN bash autogen.sh
-RUN ./configure --enable-shared="no" --enable-static="yes" --enable-silent-rules="no" --with-python="no" --with-python3="no" --with-capability_header="/usr/include/linux/capability.h" --prefix="/usr"
+RUN ./configure --enable-shared="no" --enable-static="yes" --enable-silent-rules="no" --with-python3="no" --with-capability_header="/usr/include/linux/capability.h" --prefix="/usr"
 RUN make
 RUN make install
 
@@ -130,9 +129,9 @@ ENV LIBCAPNG_LIB_PATH="/usr/lib"
 WORKDIR /workspace/build/
 RUN git clone --depth 1 --branch v${VIRTIOFSD_VERSION} https://gitlab.com/virtio-fs/virtiofsd virtiofsd-v${VIRTIOFSD_VERSION}
 
-WORKDIR /workspace/build/"virtiofsd-v${VIRTIOFSD_VERSION}"
-RUN cargo build --release --target=${RUST_ARCH}-unknown-linux-musl --all-features
-RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separate-debug-symbols --compress-debug-symbols
+WORKDIR /workspace/build/virtiofsd-v${VIRTIOFSD_VERSION}
+RUN cargo build --release --target=${RUST_ARCH}-unknown-linux-musl --all-targets
+RUN cargo deb --no-build --separate-debug-symbols --compress-debug-symbols --target=${RUST_ARCH}-unknown-linux-musl
 
 
 ###

--- a/platform/Dockerfiles/virtiofsd/Dockerfile
+++ b/platform/Dockerfiles/virtiofsd/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/library/debian:bookworm as toolchain
+FROM docker.io/library/debian:bookworm AS toolchain
 
 ENV DEBIAN_FRONTEND           noninteractive
-ENV RUST_VERSION              1.78.0
+ENV RUST_VERSION              1.80.0
 ENV RUST_ARCH                 x86_64
 
 ENV PATH                      "$PATH:/root/.cargo/bin/"
@@ -12,35 +12,32 @@ ENV PATH                      "$PATH:/root/.cargo/bin/"
 # global build dependencies
 
 RUN apt update
-RUN apt -y install curl
-RUN apt -y install git
-RUN apt -y install apt-utils
-RUN apt -y install build-essential
-RUN apt -y install gperf
-RUN apt -y install musl
-RUN apt -y install musl-tools
-RUN apt -y install musl-dev
-RUN apt -y install bindgen
-RUN apt -y install debhelper-compat
-RUN apt -y install pkg-config
-RUN apt -y install linux-libc-dev
-RUN apt -y install autoconf
-RUN apt -y install automake
-RUN apt -y install libtool
-RUN apt -y install m4
-RUN apt -y install make
-
-# Include lld linker to improve build times either by using environment variable
-# possibly install clang lld
+RUN apt --yes install curl
+RUN apt --yes install git
+RUN apt --yes install apt-utils
+RUN apt --yes install build-essential
+RUN apt --yes install gperf
+RUN apt --yes install musl
+RUN apt --yes install musl-tools
+RUN apt --yes install musl-dev
+RUN apt --yes install bindgen
+RUN apt --yes install debhelper-compat
+RUN apt --yes install pkg-config
+RUN apt --yes install linux-libc-dev
+RUN apt --yes install autoconf
+RUN apt --yes install automake
+RUN apt --yes install libtool
+RUN apt --yes install m4
+RUN apt --yes install make
 
 
 ###
 #
 # Runtime dependencies for cargo-deb
 
-RUN apt -y install dpkg
-RUN apt -y install dpkg-dev
-RUN apt -y install liblzma-dev
+RUN apt --yes install dpkg
+RUN apt --yes install dpkg-dev
+RUN apt --yes install liblzma-dev
 
 
 ###
@@ -49,56 +46,18 @@ RUN apt -y install liblzma-dev
 # https://doc.rust-lang.org/cargo/reference/unstable.html#list-of-unstable-features
 
 WORKDIR /workspace/install
-
-# wise@wise-a40x1-1:~/rustup$ rustup component list | grep musl | grep x86_64
-# cargo-x86_64-unknown-linux-musl (installed)
-# clippy-x86_64-unknown-linux-musl (installed)
-# llvm-tools-x86_64-unknown-linux-musl
-# rls-x86_64-unknown-linux-musl
-# rust-analysis-x86_64-unknown-linux-musl
-# rust-analyzer-x86_64-unknown-linux-musl
-# rust-docs-x86_64-unknown-linux-musl (installed)
-# rust-std-x86_64-unknown-linux-musl (installed)
-# rustc-x86_64-unknown-linux-musl (installed)
-# rustc-dev-x86_64-unknown-linux-musl
-# rustfmt-x86_64-unknown-linux-musl (installed)
-#--default-host=${RUST_ARCH}-unknown-linux-gnu --default-toolchain=${RUST_ARCH}-unknown-linux-musl
-# wise@wise-a40x1-1:~/rustup$ rustup toolchain list 
-# x86_64-unknown-linux-musl (installed)
-# 1.74.0-x86_64-unknown-linux-musl (default)
-
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
-RUN bash rustup-init.sh -y --default-host="${RUST_ARCH}-unknown-linux-gnu" --profile="default"
-RUN rustup toolchain add "${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu"
-RUN rustup target add "${RUST_ARCH}-unknown-linux-musl"
-#RUN rustup default "${RUST_VERSION}"
-
-
-#RUN rustup-init.sh -y --profile=default --default-host=${RUST_ARCH}-unknown-linux-gnu --default-toolchain=${RUST_VERSION}-${RUST_ARCH}-unknown-linux-musl --target=${RUST_VERSION}-${RUST_ARCH}-unknown-linux-musl
-#RUN rustup component add cargo-x86_64-unknown-linux-musl
-#RUN rustup target add --toolchain <toolchain> <target>...
-#RUN rustup target add --toolchain "${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu" "${RUST_ARCH}-unknown-linux-musl"
-#RUN rustup target add "${RUST_ARCH}-unknown-linux-musl"
-#wise@wise-a40x1-1:~$ rustup target add --toolchain "${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu" "${RUST_ARCH}-unknown-linux-musl"
-# wise@wise-a40x1-1:~/rustup$ rustup target list | grep musl | grep x86_64
-
-
-#RUN rustup component add clippy-x86_64-unknown-linux-musl
-#RUN rustup component add rustfmt-x86_64-unknown-linux-musl
-#RUN rustup component add rustc-dev-x86_64-unknown-linux-musl
-#RUN rustup component add llvm-tools-dev-x86_64-unknown-linux-musl
-#RUN rustup component add rls-dev-x86_64-unknown-linux-musl
-#RUN rustup component add rust-std-x86_64-unknown-linux-musl
-#RUN rustup component add rustc-x86_64-x86_64-unknown-linux-musl
-#RUN rustup component add rustc-dev-x86_64-x86_64-unknown-linux-musl
-#RUN rustup component add rustfmt-x86_64-x86_64-unknown-linux-musl
+RUN curl --location --remote-name https://static.rust-lang.org/rustup/dist/${RUST_ARCH}-unknown-linux-gnu/rustup-init
+RUN chmod +x rustup-init
+RUN ./rustup-init -y --profile=minimal --default-host=${RUST_ARCH}-unknown-linux-gnu --default-toolchain=${RUST_VERSION}-${RUST_ARCH}-unknown-linux-gnu --target=${RUST_ARCH}-unknown-linux-musl
+RUN cargo install cargo-feature --locked
+RUN cargo install cargo-deb --locked
 
 
 ###
 #
 # Actually build virtiofsd from the rust image just prepared.
 
-FROM toolchain as dependencies
+FROM toolchain AS dependencies
 
 ENV DEBIAN_FRONTEND           noninteractive
 ENV LIBCAP_NG_VERSION         0.8.5
@@ -114,20 +73,18 @@ ENV CPPFLAGS                  "-isystem /usr/include/x86_64-linux-musl/ -isystem
 # Prepare and build system dependencies
 
 WORKDIR /workspace/build/
-RUN curl -LOs https://github.com/stevegrubb/libcap-ng/archive/refs/tags/v${LIBCAP_NG_VERSION}.tar.gz
-RUN curl -LOs https://github.com/seccomp/libseccomp/archive/refs/tags/v${LIBSECCOMP_VERSION}.tar.gz
-
-RUN tar -xf v${LIBCAP_NG_VERSION}.tar.gz
-RUN tar -xf v${LIBSECCOMP_VERSION}.tar.gz
+RUN git clone --depth 1 --branch v${LIBCAP_NG_VERSION} https://github.com/stevegrubb/libcap-ng libcap-ng-v${LIBCAP_NG_VERSION}
+RUN git clone --depth 1 --branch v${LIBSECCOMP_VERSION} https://github.com/seccomp/libseccomp libseccomp-v${LIBSECCOMP_VERSION}
 
 
 ###
 #
 # Build libseccomp
 
-WORKDIR /workspace/build/libseccomp-${LIBSECCOMP_VERSION}
-RUN autoreconf --install --force --verbose --warning=all
+WORKDIR /workspace/build/libseccomp-v${LIBSECCOMP_VERSION}
+RUN bash autogen.sh
 RUN ./configure --enable-shared="no" --enable-static="yes" --enable-silent-rules="no" --prefix="/usr"
+RUN ls -lR /workspace/build
 RUN make
 RUN make install
 
@@ -136,9 +93,8 @@ RUN make install
 #
 # Build libcap-ng
 
-WORKDIR /workspace/build/libcap-ng-${LIBCAP_NG_VERSION}
-RUN touch NEWS
-RUN autoreconf --install --force --verbose --warning=all
+WORKDIR /workspace/build/libcap-ng-v${LIBCAP_NG_VERSION}
+RUN bash autogen.sh
 RUN ./configure --enable-shared="no" --enable-static="yes" --enable-silent-rules="no" --with-python="no" --with-python3="no" --with-capability_header="/usr/include/linux/capability.h" --prefix="/usr"
 RUN make
 RUN make install
@@ -148,65 +104,38 @@ RUN make install
 #
 # Prepare final application
 
-FROM dependencies as build_virtiofsd
+FROM dependencies AS build_virtiofsd
 ENV PATH                      "$PATH:/root/.cargo/bin/"
-ENV RUST_VERSION              1.74.0
+ENV RUST_VERSION              1.80.0
 ENV RUST_ARCH                 x86_64
-ENV VIRTIOFSD_VERSION         v1.10.1
+ENV VIRTIOFSD_VERSION         1.11.1
 ENV RUSTFLAGS                 "--codegen target-feature=+crt-static --codegen link-self-contained=yes"
 ENV LIBSECCOMP_LINK_TYPE      "static"
 ENV LIBSECCOMP_LIB_PATH       "/usr/lib"
 ENV LIBCAPNG_LINK_TYPE        "static"
 ENV LIBCAPNG_LIB_PATH         "/usr/lib"
-# -- -D warnings -D clippy::undocumented_unsafe_blocks
-# ENV RUSTFLAGS               "-D warnings -D clippy::undocumented_unsafe_blocks"
-# ENV RUSTFLAGS               "-C link-arg=-fuse-ld=lld"
-# or with Cargo's configuration file (i.e see .cargo/config.toml).
+
+
+###
+#
+# Build virtiofsd binary and debian package
 
 WORKDIR /workspace/build/
-RUN curl -l https://gitlab.com/virtio-fs/virtiofsd/-/archive/${VIRTIOFSD_VERSION}/virtiofsd-${VIRTIOFSD_VERSION}.tar.gz --output virtiofsd-${VIRTIOFSD_VERSION}.tar.gz
-RUN tar -xf virtiofsd-${VIRTIOFSD_VERSION}.tar.gz
+RUN git clone --depth 1 --branch v${VIRTIOFSD_VERSION} https://gitlab.com/virtio-fs/virtiofsd virtiofsd-v${VIRTIOFSD_VERSION}
 
-WORKDIR /workspace/build/"virtiofsd-${VIRTIOFSD_VERSION}"
-RUN cargo build --all-features --bins --future-incompat-report --locked --release --target x86_64-unknown-linux-musl
+WORKDIR /workspace/build/"virtiofsd-v${VIRTIOFSD_VERSION}"
+# Need the virtiofsd features. --all-features was here prior
+RUN cargo deb --profile release --target=${RUST_ARCH}-unknown-linux-musl --separate-debug-symbols --compress-debug-symbols -- --all-features
+
 
 ###
 #
 # Export final application to ${PWD}/target
 
 WORKDIR /workspace/target
-RUN cp -aR /workspace/build/virtiofsd-${VIRTIOFSD_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/virtiofsd /workspace/target/virtiofsd_${VIRTIOFSD_VERSION}
+RUN cp --archive --recursive /workspace/build/virtiofsd-v${VIRTIOFSD_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/release/virtiofsd /workspace/target/virtiofsd_v${VIRTIOFSD_VERSION}
+RUN cp --archive --recursive /workspace/build/virtiofsd-v${VIRTIOFSD_VERSION}/target/${RUST_ARCH}-unknown-linux-musl/debian/virtiofsd_${VIRTIOFSD_VERSION}-1_amd64.deb /workspace/target
+
 
 FROM scratch
 COPY --from=build_virtiofsd /workspace/target /
-
-
-###
-#
-# TODO(sdake): Define features
-# https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
-# TODO: cargo-copy-cult
-#        cflags="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2"
-#        ./configure --prefix="${libseccomp_install_dir}" CFLAGS="${cflags}" --enable-static
-# TODO: cargo deb will build a debian package for us
-# Although I wish to maintain the capability to have multiple hypervisor versions
-# on the same filesystem at the same time.
-#
-###
-
-# These may be important
-# https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/199/diffs
-# https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/16/diffs
-# https://gitlab.com/virtio-fs/virtiofsd/-/issues/118
-# https://gitlab.com/virtio-fs/virtiofsd/-/issues/84
-# https://gitlab.com/virtio-fs/virtiofsd/-/issues/134
-# [Awesome refresher covering autotools](https://www.lrde.epita.fr/~adl/dl/autotools.pdf)
-# https://doc.rust-lang.org/rustc/linker-plugin-lto.html
-# https://github.com/rust-cuda/wg/blob/master/documents/roadmap.md https://github.com/japaric-archived/nvptx#targets https://llvm.org/docs/LinkTimeOptimization.html
-# https://doc.rust-lang.org/cargo/reference/profiles.html#profile-settings
-# Environment: https://doc.rust-lang.org/cargo/reference/environment-variables.html
-# https://doc.rust-lang.org/cargo/reference/config.html#configuration-format
-# https://doc.rust-lang.org/cargo/reference/environment-variables.html
-# https://doc.rust-lang.org/cargo/commands/cargo-vendor.html
-# https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5941
-# https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/programmer-references/24593.pdf

--- a/platform/Dockerfiles/virtiofsd/build.sh
+++ b/platform/Dockerfiles/virtiofsd/build.sh
@@ -1,6 +1,6 @@
 date=$(date '+%Y%m%d%H%M%S')
-VIRTIOFSD_VERSION=v1.10.1
+VIRTIOFSD_VERSION=1.11.1
 
-docker buildx build --progress=plain --tag artificialwisdomai/virtiofsd:${VIRTIOFSD_VERSION}-${date} --output type=local,dest="${PWD}/target" --progress plain .
-docker buildx build --progress=plain --tag artificialwisdomai/virtiofsd:${VIRTIOFSD_VERSION}-${date} --output type=docker --progress plain .
-docker buildx build --progress=plain --tag artificialwisdomai/virtiofsd:${VIRTIOFSD_VERSION} --output type=docker --progress plain .
+docker buildx build --progress=plain --tag artificialwisdomai/virtiofsd:v${VIRTIOFSD_VERSION}-${date} --output type=local,dest="${PWD}/target" --progress plain .
+docker buildx build --progress=plain --tag artificialwisdomai/virtiofsd:v${VIRTIOFSD_VERSION}-${date} --output type=docker --progress plain .
+docker buildx build --progress=plain --tag artificialwisdomai/virtiofsd:v${VIRTIOFSD_VERSION} --output type=docker --progress plain .


### PR DESCRIPTION
    Simplify by removing comments which are in github
    Simplify by using long options instead of short options
    Simplify by
    Update rust to v1.80
    Update virtiofsd to v11.1
    Save binary and deb files
    Use cargo-deb to build virtiofsd and save debian files