### PR TITLE
Those who control the API control the business

### DIFF
--- a/platform/Dockerfiles/istiod/Dockerfile
+++ b/platform/Dockerfiles/istiod/Dockerfile
@@ -1,0 +1,45 @@
+FROM docker.io/library/debian:bookworm AS build_istiod
+
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV ISTIOD_VERSION="1.22.3"
+ENV PATH="$PATH:/usr/local/go/bin"
+ENV TARGET_ARCH="amd64"
+ENV DEB_COMPRESSION="--deb-compression=none"
+# postinst.sh may not be needed.
+ENV SIDECAR_FILES="pilot-discovery istioctl envoy pilot-agent envoy_bootstrap.json istio-start.sh istio.service sidecar.env postinst.sh"
+ENV BUILD_WITH_CONTAINER="0"
+ENV GO_VERSION="1.22.5"
+
+
+RUN apt update
+RUN apt --yes install build-essential
+RUN apt --yes install curl
+RUN apt --yes install ruby3.1
+RUN apt --yes install git
+
+RUN gem3.1 install fpm
+
+RUN mkdir -p /workspace/source
+RUN mkdir -p /workspace/build
+RUN mkdir -p /workspace/target
+
+WORKDIR /workspace/fetch
+RUN curl --location https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz --remote-name
+RUN tar -xf go${GO_VERSION}.linux-amd64.tar.gz
+RUN mv go /usr/local
+
+###
+#
+# Prepare and build cloud-hypervisor
+
+WORKDIR /workspace/source
+RUN git clone --depth 1 --branch ${ISTIOD_VERSION} https://github.com/istio/istio istiod-${ISTIOD_VERSION}
+
+WORKDIR /workspace/source/istiod-${ISTIOD_VERSION}
+RUN make build-linux
+RUN make deb
+
+RUN cp --archive --recursive /workspace/source/istiod-${ISTIOD_VERSION}/out/linux_amd64/* /workspace/target
+
+FROM scratch
+COPY --from=build_istiod /workspace/target /

--- a/platform/Dockerfiles/istiod/build.sh
+++ b/platform/Dockerfiles/istiod/build.sh
@@ -1,0 +1,6 @@
+ISTIOD_VERSION=v1.22.5
+date=$(date '+%Y%m%d%H%M%S')
+
+docker buildx build --tag artificialwisdomai/istiod:${ISTIOD_VERSION}-${date} --output type=docker --progress plain .
+docker buildx build --tag artificialwisdomai/istiod:${ISTIOD_VERSION}-${date} --output type=local,dest="${PWD}/target" --progress plain .
+docker buildx build --tag artificialwisdomai/istiod:${ISTIOD_VERSION} --output type=docker --progress plain .


### PR DESCRIPTION
The purpose of this container is to build istio-sidecar.deb. This debian package is then installed within a virtual machine which I will call the gpu service. One or more gpu service virtual machines are started on a host and then connect to https://api.computelify.com. The service macine also includes vllm to provide inference. Our other packages, such as cloud-hypervisor and virtiofsd provide the infrastructure to run the gpu services.

Once connected, the gpu service will be authz/authn to a specific namespace or namespaces. The GPU service will then provide an openai API on api.computelify.com. Its possible to add custom domains easily.

Old school models of this approach involve writing custom https and http man in the middle code which is fragile and complex. Instead, we wrap that complexity in a robust implementation of a dataplane provided by envoy and a control plane provided by Istio.

Istio offers these benefits:
- programmatic control over authorization.
- programmiatc control over authentication.
- programmatic control over ingress DNS names.
- complete zero-trsut networking strict mtls security.
- programmatic control over rate limiting.
- capability to build telemetry dashboards of any type.
- Too many other features to list. Read the custom resource dev docs at https://istio.io.

Next up, inference via vllm within a gpu service virtual machine conneced to our ingress.

    https://api.computelify.com